### PR TITLE
Update aoa.py to rectify the parameters

### DIFF
--- a/nooploop_uwb/aoa.py
+++ b/nooploop_uwb/aoa.py
@@ -11,7 +11,7 @@ class AOA(object):
     """nooploop uwb aoa parser.
     role:  1=Anchor, 2=Tag
     """
-    def __init__(self, config_path=None, port='/dev/ttyUSB1', baudrate=9216000):
+    def __init__(self, config_path=None, port='/dev/ttyUSB0', baudrate=921600):
         """
         Input:
             config_path: str


### PR DESCRIPTION
the latest version of Nooploop takes 921600 as baudrate rather than 9216000.
Also, the default port is more likely to be ttyUSB0 rather than ttyUSB1, as least it's my case :)